### PR TITLE
build: Add spring-javaformat.

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -4,6 +4,15 @@
 
 JDK 17 and Maven is required. Please run to test and package the project:
 
+WARNING: For the time beeing, you need to install a snapshot version of https://github.com/jOOQ/jOOQ[jOOQ]
+
+[source,bash]
+----
+git clone git@github.com:jOOQ/jOOQ.git
+cd jOOQ
+mvn -DskipTests -pl jOOQ -pl jOOQ-meta -am install
+----
+
 [source,bash]
 ----
 ./mvnw clean verify
@@ -55,6 +64,24 @@ When you add new files, you can run
 ----
 
 to add required headers automatically.
+
+We use https://github.com/spring-io/spring-javaformat[spring-javaformat] to format the source files.
+
+[source,bash]
+----
+./mvnw spring-javaformat:apply
+----
+
+TIP: The Spring Developers write: "The source formatter does not fundamentally change your code. For example, it will not change the order of import statements. It is effectively limited to adding or removing whitespace and line feeds."
+     This means the following checkstyle check might still fail.
+     Some common errors:
+     +
+     Static imports, import `javax.*` and `java.*` before others
+     +
+     Static imports are helpful, yes, but when working with 2 builders in the same project (here jOOQ and Cypher-DSL), they can be quite confusing.
+
+There are plugins for https://github.com/spring-io/spring-javaformat#eclipse[Eclipse] and https://github.com/spring-io/spring-javaformat#intellij-idea[IntelliJ IDEA] and the Checkstyle settings https://github.com/spring-io/spring-javaformat#checkstyle-idea-plugin[can be imported as well].
+We took those "as is" and just disabled the lambda check (requiring even single parameters to have parenthesis).
 
 === Sorting the build file
 

--- a/etc/checkstyle/config.xml
+++ b/etc/checkstyle/config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2023 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE module PUBLIC
+		"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+		"https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="com.puppycrawl.tools.checkstyle.Checker">
+	<module name="io.spring.javaformat.checkstyle.SpringChecks">
+		<property name="excludes" value="io.spring.javaformat.checkstyle.check.SpringLambdaCheck"/>
+	</module>
+</module>

--- a/etc/checkstyle/config.xml
+++ b/etc/checkstyle/config.xml
@@ -21,6 +21,7 @@
 		"https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="com.puppycrawl.tools.checkstyle.Checker">
 	<module name="io.spring.javaformat.checkstyle.SpringChecks">
+		<property name="excludes" value="io.spring.javaformat.checkstyle.check.SpringHeaderCheck"/>
 		<property name="excludes" value="io.spring.javaformat.checkstyle.check.SpringLambdaCheck"/>
 	</module>
 </module>

--- a/etc/checkstyle/suppressions.xml
+++ b/etc/checkstyle/suppressions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2023 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE suppressions PUBLIC
+		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
+		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+	<suppress checks="RegexpHeader" files="package-info\.java"/>
+	<suppress checks="[a-zA-Z0-9]*" files="[\\/]generated-test-sources[\\/]"/>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
 		<artifactsDir>${project.build.directory}</artifactsDir>
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
 		<assertj.version>3.24.1</assertj.version>
+		<checkstyle.version>10.6.0</checkstyle.version>
 		<imageName>${project.artifactId}</imageName>
 		<java.version>17</java.version>
 		<jreleaser-maven-plugin.version>1.4.0</jreleaser-maven-plugin.version>
@@ -86,6 +87,7 @@
 		<license-maven-plugin.version>4.2.rc2</license-maven-plugin.version>
 		<mainClass>org.neo4j.sql2cypher.SQLToCypher</mainClass>
 		<maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
+		<maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
 		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
 		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
@@ -95,6 +97,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<sortpom-maven-plugin.version>3.2.0</sortpom-maven-plugin.version>
+		<spring-javaformat.version>0.0.35</spring-javaformat.version>
 	</properties>
 
 	<dependencyManagement>
@@ -148,6 +151,33 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-checkstyle-plugin</artifactId>
+					<version>${maven-checkstyle-plugin.version}</version>
+					<configuration>
+						<excludes>**/module-info.java</excludes>
+						<includeTestSourceDirectory>true</includeTestSourceDirectory>
+						<configLocation>etc/checkstyle/config.xml</configLocation>
+						<suppressionsLocation>etc/checkstyle/suppressions.xml</suppressionsLocation>
+						<inputEncoding>${project.build.sourceEncoding}</inputEncoding>
+						<consoleOutput>true</consoleOutput>
+						<failsOnError>true</failsOnError>
+						<includeTestSourceDirectory>true</includeTestSourceDirectory>
+					</configuration>
+					<dependencies>
+						<dependency>
+							<groupId>com.puppycrawl.tools</groupId>
+							<artifactId>checkstyle</artifactId>
+							<version>${checkstyle.version}</version>
+						</dependency>
+						<dependency>
+							<groupId>io.spring.javaformat</groupId>
+							<artifactId>spring-javaformat-checkstyle</artifactId>
+							<version>${spring-javaformat.version}</version>
+						</dependency>
+					</dependencies>
+				</plugin>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>${maven-compiler-plugin.version}</version>
@@ -208,7 +238,6 @@
 						<exclude>**/*.extension</exclude>
 						<exclude>**/README</exclude>
 						<exclude>**/org.mockito.plugins.MockMaker</exclude>
-						<exclude>**/package-info.java</exclude>
 					</excludes>
 				</configuration>
 				<executions>
@@ -218,6 +247,34 @@
 							<goal>check</goal>
 						</goals>
 						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>io.spring.javaformat</groupId>
+				<artifactId>spring-javaformat-maven-plugin</artifactId>
+				<version>${spring-javaformat.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>validate</goal>
+						</goals>
+						<phase>validate</phase>
+						<inherited>true</inherited>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>checkstyle-validation</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<phase>validate</phase>
+						<inherited>true</inherited>
 					</execution>
 				</executions>
 			</plugin>
@@ -348,6 +405,7 @@
 				<skipITs>true</skipITs>
 				<skipNativeBuild>true</skipNativeBuild>
 				<skipTests>true</skipTests>
+				<spring-javaformat.skip>true</spring-javaformat.skip>
 			</properties>
 		</profile>
 		<profile>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 module org.neo4j.sqltocypher {
     requires org.jooq;
     requires org.neo4j.cypherdsl.core;

--- a/src/main/java/org/neo4j/sql2cypher/Config.java
+++ b/src/main/java/org/neo4j/sql2cypher/Config.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.neo4j.sql2cypher;
+
+import java.util.Map;
+
+import org.jooq.SQLDialect;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DefaultConfiguration;
+import org.neo4j.cypherdsl.core.renderer.Configuration;
+
+/**
+ * Configuration for sql2cypher, use this to configure parsing and rendering settings as
+ * well as table to node mappings.
+ *
+ * @author Michael Hunger
+ * @author Michael J. Simons
+ */
+public final class Config {
+
+	private final Settings jooqSettings;
+
+	private final Map<String, String> tableToLabelMappings;
+
+	private final SQLDialect sqlDialect;
+
+	private final Configuration cypherDslConfig;
+
+	public Config() {
+		this(Map.of(), defaultSettings(), SQLDialect.DEFAULT, Configuration.prettyPrinting());
+	}
+
+	public Config(Map<String, String> tableToLabelMappings, Settings jooqSettings, SQLDialect sqlDialect,
+			Configuration cypherDslConfig) {
+		this.tableToLabelMappings = Map.copyOf(tableToLabelMappings);
+		this.sqlDialect = sqlDialect;
+		this.jooqSettings = ((Settings) jooqSettings.clone()).withParseDialect(this.sqlDialect);
+		this.cypherDslConfig = cypherDslConfig;
+	}
+
+	public Config with(Map<String, String> tableMappings) {
+		return new Config(tableMappings, this.jooqSettings, this.sqlDialect, this.cypherDslConfig);
+	}
+
+	private static Settings defaultSettings() {
+		return new DefaultConfiguration().settings().withParseNameCase(org.jooq.conf.ParseNameCase.LOWER_IF_UNQUOTED)
+				.withRenderNameCase(org.jooq.conf.RenderNameCase.LOWER)
+				.withParseWithMetaLookups(org.jooq.conf.ParseWithMetaLookups.IGNORE_ON_FAILURE)
+				.withDiagnosticsLogging(true);
+	}
+
+	public Settings getJooqSettings() {
+		return ((Settings) this.jooqSettings.clone());
+	}
+
+	public Map<String, String> getTableToLabelMappings() {
+		return Map.copyOf(this.tableToLabelMappings);
+	}
+
+	public SQLDialect getSqlDialect() {
+		return this.sqlDialect;
+	}
+
+	public Configuration getCypherDslConfig() {
+		return this.cypherDslConfig;
+	}
+
+}

--- a/src/main/java/org/neo4j/sql2cypher/Config.java
+++ b/src/main/java/org/neo4j/sql2cypher/Config.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.neo4j.sql2cypher;
 
 import java.util.Map;

--- a/src/main/java/org/neo4j/sql2cypher/SQLToCypher.java
+++ b/src/main/java/org/neo4j/sql2cypher/SQLToCypher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.neo4j.sql2cypher;
 
 import java.util.Arrays;
@@ -23,370 +24,408 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.jooq.*;
 import org.jooq.Asterisk;
-import org.jooq.conf.ParseNameCase;
-import org.jooq.conf.ParseWithMetaLookups;
-import org.jooq.conf.RenderNameCase;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Param;
+import org.jooq.Parser;
+import org.jooq.QualifiedAsterisk;
+import org.jooq.Query;
+import org.jooq.Select;
+import org.jooq.SelectField;
+import org.jooq.SelectFieldOrAsterisk;
+import org.jooq.SortField;
+import org.jooq.Table;
+import org.jooq.TableField;
 import org.jooq.conf.Settings;
 import org.jooq.impl.DSL;
-import org.jooq.impl.DefaultConfiguration;
 import org.jooq.impl.QOM;
 import org.jooq.impl.QOM.TableAlias;
-
-import org.neo4j.cypherdsl.core.*;
 import org.neo4j.cypherdsl.core.Condition;
+import org.neo4j.cypherdsl.core.Cypher;
+import org.neo4j.cypherdsl.core.Expression;
 import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.PatternElement;
+import org.neo4j.cypherdsl.core.ResultStatement;
+import org.neo4j.cypherdsl.core.SortItem;
+import org.neo4j.cypherdsl.core.StatementBuilder;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithWhere;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithoutWhere;
-import org.neo4j.cypherdsl.core.renderer.Configuration;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
 
-import static org.jooq.impl.DSL.createTable;
-import static org.neo4j.cypherdsl.core.Functions.*;
-
 /**
- * Quick proof of concept of a jOOQ/Cypher-DSL based SQL to Cypher translator
+ * Quick proof of concept of a jOOQ/Cypher-DSL based SQL to Cypher translator.
+ *
  * @author Lukas Eder
  * @author Michael J. Simons
+ * @author Michael Hunger
  */
-public class SQLToCypher {
+public final class SQLToCypher {
 
-    public static final String TEST_STATEMENT = """
-            SELECT t.a, t.b
-            FROM my_table AS t
-            WHERE t.a = 1
-            """;
+	/**
+	 * Simple test statement.
+	 */
+	public static final String TEST_STATEMENT = """
+			SELECT t.a, t.b
+			FROM my_table AS t
+			WHERE t.a = 1
+			""";
 
-    public static void main(String[] args) {
-        var sql = args.length == 0 ? TEST_STATEMENT : String.join(" ", args);
-        var result = SQLToCypher.withoutMappings().convert(sql);
-        System.out.println(result);
-    }
+	public static void main(String[] args) {
+		var sql = (args.length == 0) ? TEST_STATEMENT : String.join(" ", args);
+		var result = SQLToCypher.withoutMappings().convert(sql);
+		System.out.println(result);
+	}
 
-    private final Config config;
+	public static SQLToCypher withoutMappings() {
+		return new SQLToCypher(new Config());
+	}
 
-    public static SQLToCypher withoutMappings(){
-        return new SQLToCypher(new Config());
-    }
+	public static SQLToCypher with(Map<String, String> tableMappings) {
+		return new SQLToCypher(new Config().with(tableMappings));
+	}
 
-    public static SQLToCypher with(Map<String, String> tableMappings) {
-        return new SQLToCypher(new Config().with(tableMappings));
-    }
-    public static SQLToCypher with(Config config) {
-        return new SQLToCypher(config);
-    }
+	public static SQLToCypher with(Config config) {
+		return new SQLToCypher(config);
+	}
 
-    public static class Config {
-        private final Settings jooqSettings;
-        private final Map<String,String> tableToLabelMappings;
-        private final SQLDialect sqlDialect;
-        private final Configuration cypherDslConfig;
+	private final Config config;
 
-        public Config() {
-            this(Map.of(), defaultSettings(), SQLDialect.DEFAULT, Configuration.prettyPrinting());
-        }
+	private final Map<Table<?>, Node> tables = new HashMap<>();
 
-        public Config(Map<String, String> tableToLabelMappings, Settings jooqSettings, SQLDialect sqlDialect, Configuration cypherDslConfig) {
-            this.jooqSettings = jooqSettings;
-            this.tableToLabelMappings = tableToLabelMappings;
-            this.sqlDialect = sqlDialect;
-            this.cypherDslConfig = cypherDslConfig;
-        }
+	private SQLToCypher(Config config) {
+		this.config = config;
+	}
 
-        public Config with(Map<String, String> tableMappings) {
-            return new Config(tableMappings, this.jooqSettings, this.sqlDialect, this.cypherDslConfig);
-        }
+	private DSLContext configure(Config config) {
+		Settings jooqConfig = config.getJooqSettings();
+		DSLContext dsl = DSL.using(config.getSqlDialect(), jooqConfig);
+		dsl.configuration().set(() -> {
+			var queries = config.getTableToLabelMappings().entrySet().stream()
+					.map((e) -> (Query) DSL.createTable(e.getKey()).comment("label=" + e.getValue())).toList();
+			return dsl.meta(queries.toArray(Query[]::new));
+		});
+		return dsl;
+	}
 
-        private static Settings defaultSettings() {
-            return new DefaultConfiguration().settings()
-                    .withParseNameCase(ParseNameCase.LOWER_IF_UNQUOTED) // Should be configurable
-                    .withRenderNameCase(RenderNameCase.LOWER)
-                    .withParseWithMetaLookups(ParseWithMetaLookups.IGNORE_ON_FAILURE)
-                    .withDiagnosticsLogging(true);
-        }
+	// Unsure how thread safe this should be (wrt the node lookup table), but this here
+	// will do for the purpose of adding some tests
+	public String convert(String sql) {
+		Select<?> query = parse(sql);
+		ResultStatement statement = statement(query);
+		return render(statement);
+	}
 
-        private Settings getJooqSettings() {
-            return jooqSettings.withParseDialect(sqlDialect);
-        }
+	private String render(ResultStatement statement) {
+		Renderer renderer = Renderer.getRenderer(this.config.getCypherDslConfig());
+		return renderer.render(statement);
+	}
 
-        private Map<String, String> getTableToLabelMappings() {
-            return tableToLabelMappings;
-        }
+	private Select<?> parse(String sql) {
+		DSLContext dsl = configure(this.config);
+		Parser parser = dsl.parser();
+		return parser.parseSelect(sql);
+	}
 
-        private SQLDialect getSqlDialect() {
-            return sqlDialect;
-        }
+	ResultStatement statement(Select<?> x) {
 
-        private Configuration getCypherDslConfig() {
-            return cypherDslConfig;
-        }
-    }
-    private final Map<Table<?>, Node> tables = new HashMap<>();
+		// Done lazy as otherwise the property containers won't be resolved
+		Supplier<List<Expression>> resultColumnsSupplier = () -> x.$select().stream()
+				.map((t) -> (Expression) expression(t)).toList();
 
-    private SQLToCypher(Config config) {
-        this.config = config;
-    }
+		if (x.$from().isEmpty()) {
+			return Cypher.returning(resultColumnsSupplier.get()).build();
+		}
 
-    private DSLContext configure(Config config) {
-        Settings jooqConfig = config.getJooqSettings();
-        DSLContext dsl = DSL.using(config.getSqlDialect(), jooqConfig);
-        dsl.configuration().set(() -> {
-            var queries = config.getTableToLabelMappings().entrySet()
-                    .stream()
-                    .map(e -> (Query) createTable(e.getKey()).comment("label=" + e.getValue()))
-                    .toList();
-            return dsl.meta(queries.toArray(Query[]::new));
-        });
-        return dsl;
-    }
+		OngoingReadingWithoutWhere m1 = Cypher.match(x.$from().stream().map((t) -> {
+			Node node = node(t);
+			this.tables.put(t, node);
+			return (PatternElement) node;
+		}).toList());
 
-    // Unsure how thread safe this should be (wrt the node lookup table), but this here will do for the purpose of adding some tests
-    public String convert(String sql) {
-        Select<?> query = parse(sql);
-        ResultStatement statement = statement(query);
-        return render(statement);
-    }
+		OngoingReadingWithWhere m2 = (x.$where() != null) ? m1.where(condition(x.$where()))
+				: (OngoingReadingWithWhere) m1;
 
-    String render(ResultStatement statement) {
-        Renderer renderer = Renderer.getRenderer(config.getCypherDslConfig());
-        return renderer.render(statement);
-    }
+		var returning = m2.returning(resultColumnsSupplier.get())
+				.orderBy(x.$orderBy().stream().map(this::expression).toList());
 
-    private Select<?> parse(String sql) {
-        DSLContext dsl = configure(config);
-        Parser parser = dsl.parser();
-        return parser.parseSelect(sql);
-    }
+		StatementBuilder.BuildableStatement<ResultStatement> buildableStatement;
+		if (!(x.$limit() instanceof Param<?> param)) {
+			buildableStatement = returning;
+		}
+		else {
+			buildableStatement = returning.limit(expression(param));
+		}
 
-    ResultStatement statement(Select<?> x) {
+		return buildableStatement.build();
+	}
 
-        // Done lazy as otherwise the property containers won't be resolved
-        Supplier<List<Expression>> resultColumnsSupplier = () -> x.$select().stream().map(t -> (Expression) expression(t)).toList();
+	private Expression expression(SelectFieldOrAsterisk t) {
+		if (t instanceof SelectField<?> s) {
+			return expression(s);
+		}
+		else if (t instanceof Asterisk) {
+			return Cypher.asterisk();
+		}
+		else if (t instanceof QualifiedAsterisk q) {
+			return node(q.$table()).getSymbolicName().orElseGet(() -> Cypher.name(q.$table().getName()));
+		}
+		else {
+			throw new IllegalArgumentException("unsupported: " + t);
+		}
+	}
 
-        if (x.$from().isEmpty()) {
-            return Cypher.returning(resultColumnsSupplier.get()).build();
-        }
+	private Expression expression(SelectField<?> s) {
+		if (s instanceof QOM.FieldAlias<?> fa) {
+			return expression(fa.$aliased()).as(fa.$alias().last());
+		}
+		else if (s instanceof Field<?> f) {
+			return expression(f);
+		}
+		else {
+			throw new IllegalArgumentException("unsupported: " + s);
+		}
+	}
 
-        OngoingReadingWithoutWhere m1 = Cypher
-            .match(x.$from().stream().map(t -> {
-                Node node = node(t);
-                tables.put(t, node);
-                return (PatternElement) node;
-            }).toList());
+	private SortItem expression(SortField<?> s) {
+		return Cypher.sort(expression(s.$field()),
+				SortItem.Direction.valueOf(s.$sortOrder().name().toUpperCase(Locale.ROOT)));
+	}
 
-        OngoingReadingWithWhere m2 = x.$where() != null
-             ? m1.where(condition(x.$where()))
-             : (OngoingReadingWithWhere) m1;
+	private Expression expression(Field<?> f) {
+		if (f instanceof Param<?> p) {
+			if (p.$inline()) {
+				return Cypher.literalOf(p.getValue());
+			}
+			else if (p.getParamName() != null) {
+				return Cypher.parameter(p.getParamName(), p.getValue());
+			}
+			else {
+				return Cypher.anonParameter(p.getValue());
+			}
+		}
+		else if (f instanceof TableField<?, ?> tf) {
+			return lookupNode(tf.getTable()).property(tf.getName());
+		}
+		else if (f instanceof QOM.Add<?> e) {
+			return expression(e.$arg1()).add(expression(e.$arg2()));
+		}
+		else if (f instanceof QOM.Sub<?> e) {
+			return expression(e.$arg1()).subtract(expression(e.$arg2()));
+		}
+		else if (f instanceof QOM.Mul<?> e) {
+			return expression(e.$arg1()).multiply(expression(e.$arg2()));
+		}
+		else if (f instanceof QOM.Square<?> e) {
+			return expression(e.$arg1()).multiply(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Div<?> e) {
+			return expression(e.$arg1()).divide(expression(e.$arg2()));
+		}
+		else if (f instanceof QOM.Neg<?> e) {
+			throw new IllegalArgumentException("unsupported: " + e);
+		}
 
-        var returning = m2.returning(resultColumnsSupplier.get())
-            .orderBy(x.$orderBy().stream().map(this::expression).toList());
+		// https://neo4j.com/docs/cypher-manual/current/functions/mathematical-numeric/
+		else if (f instanceof QOM.Abs<?> e) {
+			return org.neo4j.cypherdsl.core.Functions.abs(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Ceil<?> e) {
+			return org.neo4j.cypherdsl.core.Functions.ceil(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Floor<?> e) {
+			return org.neo4j.cypherdsl.core.Functions.floor(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Round<?> e) {
+			if (e.$arg2() == null) {
+				return org.neo4j.cypherdsl.core.Functions.round(expression(e.$arg1()));
+			}
+			else {
+				return org.neo4j.cypherdsl.core.Functions.round(expression(e.$arg1()), expression(e.$arg2()));
+			}
+		}
+		else if (f instanceof QOM.Sign e) {
+			return org.neo4j.cypherdsl.core.Functions.sign(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Rand) {
+			return Functions.rand();
+		}
 
+		// https://neo4j.com/docs/cypher-manual/current/functions/mathematical-logarithmic/
+		else if (f instanceof QOM.Euler) {
+			return Functions.e();
+		}
+		else if (f instanceof QOM.Exp e) {
+			return Functions.exp(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Ln e) {
+			return org.neo4j.cypherdsl.core.Functions.log(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Log e) {
+			return org.neo4j.cypherdsl.core.Functions.log(expression(e.$arg1()))
+					.divide(org.neo4j.cypherdsl.core.Functions.log(expression(e.$arg2())));
+		}
+		else if (f instanceof QOM.Log10 e) {
+			return org.neo4j.cypherdsl.core.Functions.log10(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Sqrt e) {
+			return org.neo4j.cypherdsl.core.Functions.sqrt(expression(e.$arg1()));
+		}
+		// TODO: Hyperbolic functions
 
-        StatementBuilder.BuildableStatement<ResultStatement> buildableStatement;
-        if (!(x.$limit() instanceof Param<?> param)) {
-            buildableStatement = returning;
-        } else {
-            buildableStatement = returning.limit(expression(param));
-        }
+		// https://neo4j.com/docs/cypher-manual/current/functions/mathematical-trigonometric/
+		else if (f instanceof QOM.Acos e) {
+			return org.neo4j.cypherdsl.core.Functions.acos(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Asin e) {
+			return org.neo4j.cypherdsl.core.Functions.asin(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Atan e) {
+			return org.neo4j.cypherdsl.core.Functions.atan(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Atan2 e) {
+			return org.neo4j.cypherdsl.core.Functions.atan2(expression(e.$arg1()), expression(e.$arg2()));
+		}
+		else if (f instanceof QOM.Cos e) {
+			return org.neo4j.cypherdsl.core.Functions.cos(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Cot e) {
+			return org.neo4j.cypherdsl.core.Functions.cot(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Degrees e) {
+			return org.neo4j.cypherdsl.core.Functions.degrees(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Pi) {
+			return Functions.pi();
+		}
+		else if (f instanceof QOM.Radians e) {
+			return org.neo4j.cypherdsl.core.Functions.radians(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Sin e) {
+			return org.neo4j.cypherdsl.core.Functions.sin(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Tan e) {
+			return org.neo4j.cypherdsl.core.Functions.tan(expression(e.$arg1()));
+		}
 
-        return buildableStatement.build();
-    }
+		// https://neo4j.com/docs/cypher-manual/current/functions/string/
+		else if (f instanceof QOM.Cast<?> e) {
+			if (e.$dataType().isString()) {
+				return Functions.toString(expression(e.$field()));
+			}
+			else {
+				throw new IllegalArgumentException("unsupported: " + f);
+			}
+		}
+		else if (f instanceof QOM.Left e) {
+			// TODO: Support this in Cypher-DSL
+			throw new IllegalArgumentException("unsupported: " + e);
+		}
+		else if (f instanceof QOM.Lower e) {
+			return org.neo4j.cypherdsl.core.Functions.toLower(expression(e.$arg1()));
+		}
+		else if (f instanceof QOM.Ltrim e) {
+			// TODO: Support this in Cypher-DSL
+			throw new IllegalArgumentException("unsupported: " + e);
+		}
+		else if (f instanceof QOM.Replace e) {
+			// TODO: Support this in Cypher-DSL
+			throw new IllegalArgumentException("unsupported: " + e);
+		}
+		else if (f instanceof QOM.Reverse e) {
+			// TODO: Support this in Cypher-DSL
+			throw new IllegalArgumentException("unsupported: " + e);
+		}
+		else if (f instanceof QOM.Right e) {
+			// TODO: Support this in Cypher-DSL
+			throw new IllegalArgumentException("unsupported: " + e);
+		}
+		else if (f instanceof QOM.Rtrim e) {
+			// TODO: Support this in Cypher-DSL
+			throw new IllegalArgumentException("unsupported: " + e);
+		}
+		else if (f instanceof QOM.Substring e) {
+			// TODO: Support this in Cypher-DSL
+			throw new IllegalArgumentException("unsupported: " + e);
+		}
+		else if (f instanceof QOM.Trim e) {
+			if (e.$arg2() != null) {
+				throw new IllegalArgumentException("unsupported: " + e);
+			}
+			else {
+				return Functions.trim(expression(e.$arg1()));
+			}
+		}
+		else if (f instanceof QOM.Upper e) {
+			// TODO: Support this in Cypher-DSL
+			throw new IllegalArgumentException("unsupported: " + e);
+		}
+		else {
+			throw new IllegalArgumentException("unsupported: " + f);
+		}
+	}
 
-    private Expression expression(SelectFieldOrAsterisk t) {
-        if (t instanceof SelectField<?> s) {
-            return expression(s);
-        } else if(t instanceof Asterisk) {
-            return Cypher.asterisk();
-        } else if(t instanceof QualifiedAsterisk q){
-            return node(q.$table()).getSymbolicName().orElseGet(() -> Cypher.name(q.$table().getName()));
-        } else {
-            throw new IllegalArgumentException("unsupported: " + t);
-        }
-    }
+	private Condition condition(org.jooq.Condition c) {
+		if (c instanceof QOM.And a) {
+			return condition(a.$arg1()).and(condition(a.$arg2()));
+		}
+		else if (c instanceof QOM.Or o) {
+			return condition(o.$arg1()).or(condition(o.$arg2()));
+		}
+		else if (c instanceof QOM.Xor o) {
+			return condition(o.$arg1()).xor(condition(o.$arg2()));
+		}
+		else if (c instanceof QOM.Not o) {
+			return condition(o.$arg1()).not();
+		}
+		else if (c instanceof QOM.Eq<?> e) {
+			return expression(e.$arg1()).eq(expression(e.$arg2()));
+		}
+		else if (c instanceof QOM.Gt<?> e) {
+			return expression(e.$arg1()).gt(expression(e.$arg2()));
+		}
+		else if (c instanceof QOM.Lt<?> e) {
+			return expression(e.$arg1()).lt(expression(e.$arg2()));
+		}
+		else if (c instanceof QOM.Ne<?> e) {
+			return expression(e.$arg1()).ne(expression(e.$arg2()));
+		}
+		else {
+			throw new IllegalArgumentException("unsupported: " + c);
+		}
+	}
 
-    private Expression expression(SelectField<?> s) {
-        if (s instanceof QOM.FieldAlias<?> fa)
-            return expression(fa.$aliased()).as(fa.$alias().last());
-        else if (s instanceof Field<?> f)
-            return expression(f);
-        else
-            throw new IllegalArgumentException("unsupported: " + s);
-    }
+	private Node node(Table<?> t) {
+		if (t instanceof TableAlias<?> ta) {
+			return node(ta.$aliased()).named(ta.$alias().last());
+		}
+		else {
+			return Cypher.node(nodeName(t));
+		}
+	}
 
-    private SortItem expression(SortField<?> s) {
-        return Cypher.sort(expression(s.$field()), SortItem.Direction.valueOf(s.$sortOrder().name().toUpperCase(Locale.ROOT)));
-    }
+	private String nodeName(Table<?> t) {
 
-    private Expression expression(Field<?> f) {
-        if (f instanceof Param<?> p)
-            if (p.$inline())
-                return Cypher.literalOf(p.getValue());
-            else if (p.getParamName() != null)
-                return Cypher.parameter(p.getParamName(), p.getValue());
-            else
-                return Cypher.anonParameter(p.getValue());
-        else if (f instanceof TableField<?, ?> tf)
-            return lookupNode(tf.getTable()).property(tf.getName());
-        else if (f instanceof QOM.Add<?> e)
-            return expression(e.$arg1()).add(expression(e.$arg2()));
-        else if (f instanceof QOM.Sub<?> e)
-            return expression(e.$arg1()).subtract(expression(e.$arg2()));
-        else if (f instanceof QOM.Mul<?> e)
-            return expression(e.$arg1()).multiply(expression(e.$arg2()));
-        else if (f instanceof QOM.Square<?> e)
-            return expression(e.$arg1()).multiply(expression(e.$arg1()));
-        else if (f instanceof QOM.Div<?> e)
-            return expression(e.$arg1()).divide(expression(e.$arg2()));
-        else if (f instanceof QOM.Neg<?> e)
-            throw new IllegalArgumentException("unsupported: " + e);
+		var comment = t.getComment();
+		if (!comment.isBlank()) {
+			var config = Arrays.stream(comment.split(",")).map((s) -> s.split("="))
+					.collect(Collectors.toMap((a) -> a[0], (a) -> a[1]));
+			return config.getOrDefault("label", t.getName());
+		}
 
-        // https://neo4j.com/docs/cypher-manual/current/functions/mathematical-numeric/
-        else if (f instanceof QOM.Abs<?> e)
-            return abs(expression(e.$arg1()));
-        else if (f instanceof QOM.Ceil<?> e)
-            return ceil(expression(e.$arg1()));
-        else if (f instanceof QOM.Floor<?> e)
-            return floor(expression(e.$arg1()));
-        else if (f instanceof QOM.Round<?> e)
-            if (e.$arg2() == null)
-                return round(expression(e.$arg1()));
-            else
-                return round(expression(e.$arg1()), expression(e.$arg2()));
-        else if (f instanceof QOM.Sign e)
-            return sign(expression(e.$arg1()));
-        else if (f instanceof QOM.Rand)
-            return Functions.rand();
+		return t.getName();
+	}
 
-        // https://neo4j.com/docs/cypher-manual/current/functions/mathematical-logarithmic/
-        else if (f instanceof QOM.Euler)
-            return Functions.e();
-        else if (f instanceof QOM.Exp e)
-            return Functions.exp(expression(e.$arg1()));
-        else if (f instanceof QOM.Ln e)
-            return log(expression(e.$arg1()));
-        else if (f instanceof QOM.Log e)
-            return log(expression(e.$arg1())).divide(log(expression(e.$arg2())));
-        else if (f instanceof QOM.Log10 e)
-            return log10(expression(e.$arg1()));
-        else if (f instanceof QOM.Sqrt e)
-            return sqrt(expression(e.$arg1()));
-        // TODO: Hyperbolic functions
+	private Node lookupNode(Table<?> t) {
+		Node node = this.tables.get(t);
 
-        // https://neo4j.com/docs/cypher-manual/current/functions/mathematical-trigonometric/
-        else if (f instanceof QOM.Acos e)
-            return acos(expression(e.$arg1()));
-        else if (f instanceof QOM.Asin e)
-            return asin(expression(e.$arg1()));
-        else if (f instanceof QOM.Atan e)
-            return atan(expression(e.$arg1()));
-        else if (f instanceof QOM.Atan2 e)
-            return atan2(expression(e.$arg1()), expression(e.$arg2()));
-        else if (f instanceof QOM.Cos e)
-            return cos(expression(e.$arg1()));
-        else if (f instanceof QOM.Cot e)
-            return cot(expression(e.$arg1()));
-        else if (f instanceof QOM.Degrees e)
-            return degrees(expression(e.$arg1()));
-        else if (f instanceof QOM.Pi)
-            return Functions.pi();
-        else if (f instanceof QOM.Radians e)
-            return radians(expression(e.$arg1()));
-        else if (f instanceof QOM.Sin e)
-            return sin(expression(e.$arg1()));
-        else if (f instanceof QOM.Tan e)
-            return tan(expression(e.$arg1()));
+		if (node != null) {
+			return node;
+		}
+		else {
+			return node(t);
+		}
+	}
 
-        // https://neo4j.com/docs/cypher-manual/current/functions/string/
-        else if (f instanceof QOM.Cast<?> e)
-            if (e.$dataType().isString())
-                return Functions.toString(expression(e.$field()));
-            else
-                throw new IllegalArgumentException("unsupported: " + f);
-        else if (f instanceof QOM.Left e)
-            // TODO: Support this in Cypher-DSL
-            throw new IllegalArgumentException("unsupported: " + e);
-        else if (f instanceof QOM.Lower e)
-            return toLower(expression(e.$arg1()));
-        else if (f instanceof QOM.Ltrim e)
-            // TODO: Support this in Cypher-DSL
-            throw new IllegalArgumentException("unsupported: " + e);
-        else if (f instanceof QOM.Replace e)
-            // TODO: Support this in Cypher-DSL
-            throw new IllegalArgumentException("unsupported: " + e);
-        else if (f instanceof QOM.Reverse e)
-            // TODO: Support this in Cypher-DSL
-            throw new IllegalArgumentException("unsupported: " + e);
-        else if (f instanceof QOM.Right e)
-            // TODO: Support this in Cypher-DSL
-            throw new IllegalArgumentException("unsupported: " + e);
-        else if (f instanceof QOM.Rtrim e)
-            // TODO: Support this in Cypher-DSL
-            throw new IllegalArgumentException("unsupported: " + e);
-        else if (f instanceof QOM.Substring e)
-            // TODO: Support this in Cypher-DSL
-            throw new IllegalArgumentException("unsupported: " + e);
-        else if (f instanceof QOM.Trim e)
-            if (e.$arg2() != null)
-                throw new IllegalArgumentException("unsupported: " + e);
-            else
-                return Functions.trim(expression(e.$arg1()));
-        else if (f instanceof QOM.Upper e)
-            // TODO: Support this in Cypher-DSL
-            throw new IllegalArgumentException("unsupported: " + e);
-
-        else
-            throw new IllegalArgumentException("unsupported: " + f);
-    }
-
-    private Condition condition(org.jooq.Condition c) {
-        if (c instanceof QOM.And a)
-            return condition(a.$arg1()).and(condition(a.$arg2()));
-        else if (c instanceof QOM.Or o)
-            return condition(o.$arg1()).or(condition(o.$arg2()));
-        else if (c instanceof QOM.Xor o)
-            return condition(o.$arg1()).xor(condition(o.$arg2()));
-        else if (c instanceof QOM.Not o)
-            return condition(o.$arg1()).not();
-        else if (c instanceof QOM.Eq<?> e)
-            return expression(e.$arg1()).eq(expression(e.$arg2()));
-        else if (c instanceof QOM.Gt<?> e)
-            return expression(e.$arg1()).gt(expression(e.$arg2()));
-        else if (c instanceof QOM.Lt<?> e)
-            return expression(e.$arg1()).lt(expression(e.$arg2()));
-        else if (c instanceof QOM.Ne<?> e)
-            return expression(e.$arg1()).ne(expression(e.$arg2()));
-        else
-            throw new IllegalArgumentException("unsupported: " + c);
-    }
-
-    private Node node(Table<?> t) {
-        if (t instanceof TableAlias<?> ta)
-            return node(ta.$aliased()).named(ta.$alias().last());
-        else {
-            return Cypher.node(nodeName(t));
-        }
-    }
-
-    private String nodeName(Table<?> t) {
-
-        var comment = t.getComment();
-        if (!comment.isBlank()) {
-            var config = Arrays.stream(comment.split(",")).map(s -> s.split("="))
-                .collect(Collectors.toMap(a -> a[0], a -> a[1]));
-            return config.getOrDefault("label", t.getName());
-        }
-
-        return t.getName();
-    }
-
-    private Node lookupNode(Table<?> t) {
-        Node node = tables.get(t);
-
-        if (node != null)
-            return node;
-        else
-            return node(t);
-    }
 }

--- a/src/main/java/org/neo4j/sql2cypher/SQLToCypher.java
+++ b/src/main/java/org/neo4j/sql2cypher/SQLToCypher.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.neo4j.sql2cypher;
 
 import java.util.Arrays;

--- a/src/main/java/org/neo4j/sql2cypher/package-info.java
+++ b/src/main/java/org/neo4j/sql2cypher/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-module org.neo4j.sqltocypher {
-    requires org.jooq;
-    requires org.neo4j.cypherdsl.core;
-}
+/**
+ * Contains the sql2cypher translator and a CLI application.
+ */
+package org.neo4j.sql2cypher;

--- a/src/test/java/org/neo4j/sql2cypher/SQLToCypherTest.java
+++ b/src/test/java/org/neo4j/sql2cypher/SQLToCypherTest.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.neo4j.sql2cypher;
 
 import java.io.File;

--- a/src/test/java/org/neo4j/sql2cypher/SQLToCypherTest.java
+++ b/src/test/java/org/neo4j/sql2cypher/SQLToCypherTest.java
@@ -13,21 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.sql2cypher;
 
-import static org.assertj.core.api.Assertions.assertThat;
+package org.neo4j.sql2cypher;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,83 +39,82 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Michael J. Simons
  */
 class SQLToCypherTest {
 
-    static List<TestData> getTestData(Path path) {
-        try (var asciidoctor = Asciidoctor.Factory.create()) {
-            var collector = new TestDataExtractor();
-            asciidoctor.javaExtensionRegistry().treeprocessor(collector);
+	static List<TestData> getTestData(Path path) {
+		try (var asciidoctor = Asciidoctor.Factory.create()) {
+			var collector = new TestDataExtractor();
+			asciidoctor.javaExtensionRegistry().treeprocessor(collector);
 
-            var content = Files.readString(path);
-            asciidoctor.load(content, Options.builder().build());
-            return collector.testData;
-        } catch (IOException ioe) {
-            throw new RuntimeException("Error reading TCK file " + path, ioe);
-        }
-    }
+			var content = Files.readString(path);
+			asciidoctor.load(content, Options.builder().build());
+			return collector.testData;
+		}
+		catch (IOException ioe) {
+			throw new RuntimeException("Error reading TCK file " + path, ioe);
+		}
+	}
 
-    static Stream<Arguments> simple() throws Exception {
+	static Stream<Arguments> simple() throws Exception {
 
-        var path = ClassLoader.getSystemResource("simple.adoc").getPath();
-        var parentFolder = new File(path).getParentFile();
-        if (!parentFolder.isDirectory()) return Stream.empty();
+		var path = ClassLoader.getSystemResource("simple.adoc").getPath();
+		var parentFolder = new File(path).getParentFile();
+		if (!parentFolder.isDirectory()) {
+			return Stream.empty();
+		}
 
-        var files = parentFolder.listFiles((f) -> f.getName().toLowerCase().endsWith(".adoc"));
-        if (files == null) return Stream.empty();
-        return Arrays.stream(files)
-                .peek(System.out::println)
-                .flatMap(file ->
-                        getTestData(file.toPath()).stream()
-                                .map(t -> Arguments.of(t.name(), t.sql(), t.cypher(), t.tableMappings())));
-    }
+		var files = parentFolder.listFiles((f) -> f.getName().toLowerCase().endsWith(".adoc"));
+		if (files == null) {
+			return Stream.empty();
+		}
+		return Arrays.stream(files).peek(System.out::println).flatMap((file) -> getTestData(file.toPath()).stream()
+				.map((t) -> Arguments.of(t.name(), t.sql(), t.cypher(), t.tableMappings())));
+	}
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource
-    void simple(String name, String sql, String expected, Map<String, String> tableMappings) {
-        assertThat(SQLToCypher.with(tableMappings).convert(sql)).isEqualTo(expected);
-    }
+	@ParameterizedTest(name = "{0}")
+	@MethodSource
+	void simple(String name, String sql, String expected, Map<String, String> tableMappings) {
+		assertThat(SQLToCypher.with(tableMappings).convert(sql)).isEqualTo(expected);
+	}
 
-    private static class TestDataExtractor extends Treeprocessor {
+	private static class TestDataExtractor extends Treeprocessor {
 
-        private final List<TestData> testData = new ArrayList<>();
+		private final List<TestData> testData = new ArrayList<>();
 
-        TestDataExtractor() {
-            super(new HashMap<>()); // Must be mutable
-        }
+		TestDataExtractor() {
+			super(new HashMap<>()); // Must be mutable
+		}
 
-        @Override
-        public Document process(Document document) {
+		@Override
+		public Document process(Document document) {
 
-            var blocks = document
-                    .findBy(Map.of("context", ":listing", "style", "source"))
-                    .stream()
-                    .map(Block.class::cast)
-                    .filter(b -> b.hasAttribute("id"))
-                    .collect(Collectors.toMap(ContentNode::getId, Function.identity()));
+			var blocks = document.findBy(Map.of("context", ":listing", "style", "source")).stream()
+					.map(Block.class::cast).filter((b) -> b.hasAttribute("id"))
+					.collect(Collectors.toMap(ContentNode::getId, Function.identity()));
 
-            blocks.values().stream()
-                    .filter(b -> "sql".equals(b.getAttribute("language")))
-                    .map(sqlBlock -> {
-                        var name = (String) sqlBlock.getAttribute("name");
-                        var sql = String.join("\n", sqlBlock.getLines());
-                        var cypher = String.join("\n", blocks.get(sqlBlock.getId() + "_expected").getLines());
-                        Map<String, String> tableMappings = new HashMap<>();
-                        if (sqlBlock.getAttribute("table_mappings") != null) {
-                            tableMappings = Arrays.stream(((String) sqlBlock.getAttribute("table_mappings")).split(","))
-                                    .map(String::trim)
-                                    .map(s -> s.split(":"))
-                                    .collect(Collectors.toMap(a -> a[0], a -> a[1]));
-                        }
-                        return new TestData(name, sql, cypher, tableMappings);
-                    })
-                    .forEach(testData::add);
-            return document;
-        }
-    }
+			blocks.values().stream().filter((b) -> "sql".equals(b.getAttribute("language"))).map((sqlBlock) -> {
+				var name = (String) sqlBlock.getAttribute("name");
+				var sql = String.join("\n", sqlBlock.getLines());
+				var cypher = String.join("\n", blocks.get(sqlBlock.getId() + "_expected").getLines());
+				Map<String, String> tableMappings = new HashMap<>();
+				if (sqlBlock.getAttribute("table_mappings") != null) {
+					tableMappings = Arrays.stream(((String) sqlBlock.getAttribute("table_mappings")).split(","))
+							.map(String::trim).map((s) -> s.split(":"))
+							.collect(Collectors.toMap((a) -> a[0], (a) -> a[1]));
+				}
+				return new TestData(name, sql, cypher, tableMappings);
+			}).forEach(this.testData::add);
+			return document;
+		}
 
-    private record TestData(String name, String sql, String cypher, Map<String, String> tableMappings) {
-    }
+	}
+
+	private record TestData(String name, String sql, String cypher, Map<String, String> tableMappings) {
+	}
+
 }


### PR DESCRIPTION
* Reformatted sources
* Externalized `Config.java`
* Added information to `CONTRIBUTING.adoc`

I picked spring-javaformat because it's the most common ground (no palantir, well documented, defaults to tabs. cypher-dsl itself uses my own checkstyle config and I don't want to force my opinion on anyone here (albeit, my config is mostly a copy of an older spring format version).

Closes #12.