### PR TITLE
build: Parse and render expected Cypher.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,12 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-cypher-dsl-parser</artifactId>
+			<version>${neo4j-cypher-dsl.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/test/resources/expressions.adoc
+++ b/src/test/resources/expressions.adoc
@@ -172,7 +172,11 @@ will be transpiled to
 
 [source,cypher,id=t7_1_expected]
 ----
-RETURN CASE WHEN 1 = 2 THEN 3 END, CASE WHEN 1 = 2 THEN 3 ELSE 4 END, CASE WHEN 1 = 2 THEN 3 WHEN 4 = 5 THEN 6 END, CASE WHEN 1 = 2 THEN 3 WHEN 4 = 5 THEN 6 ELSE 7 END
+RETURN
+    CASE WHEN 1 = 2 THEN 3 END,
+    CASE WHEN 1 = 2 THEN 3 ELSE 4 END,
+    CASE WHEN 1 = 2 THEN 3 WHEN 4 = 5 THEN 6 END,
+    CASE WHEN 1 = 2 THEN 3 WHEN 4 = 5 THEN 6 ELSE 7 END
 ----
 
 === `CASE` abbreviations (which aren't `COALESCE` or `NVL`)


### PR DESCRIPTION
There is an escape hatch for scenarios in which the parser is broken or missing features:

Adding `parseCypher=false` to the block with expected Cypher will disable that behaviour.

When `parseCypher` is on, pretty printing during tests will be disabled.

Closes #24
