### PR TITLE
build: Use jOOQ `version-3.18.0-sql2cypher` for all builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: jOOQ/jOOQ
+          ref: version-3.18.0-sql2cypher
           path: jOOQ
 
       - name: 'Install jOOQ Snapshot'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: jOOQ/jOOQ
+          ref: version-3.18.0-sql2cypher
           path: jOOQ
 
       - name: 'Install jOOQ Snapshot'


### PR DESCRIPTION
Closes #27.