### PR TITLE
refactor: Always name nodes.

### DIFF
--- a/src/main/java/org/neo4j/sql2cypher/Translator.java
+++ b/src/main/java/org/neo4j/sql2cypher/Translator.java
@@ -131,11 +131,6 @@ public final class Translator {
 	Statement statement(QOM.Delete<?> d) {
 		Node e = lookupNode(d.$from());
 
-		// TODO: https://github.com/neo4j-contrib/cypher-dsl/issues/585
-		// We shouldn't need to label things like this, but otherwise, it's not possible
-		// to write an assertion as labels are generated randomly, currently.
-		e = e.named(d.$from().getName());
-		this.tables.put(d.$from(), e);
 		OngoingReadingWithoutWhere m1 = Cypher.match(e);
 		OngoingReadingWithWhere m2 = (d.$where() != null) ? m1.where(condition(d.$where()))
 				: (OngoingReadingWithWhere) m1;
@@ -558,10 +553,10 @@ public final class Translator {
 
 	private Node node(Table<?> t) {
 		if (t instanceof TableAlias<?> ta) {
-			return node(ta.$aliased()).named(ta.$alias().last());
+			return Cypher.node(nodeName(ta.$aliased())).named(ta.$alias().last());
 		}
 		else {
-			return Cypher.node(nodeName(t));
+			return Cypher.node(nodeName(t)).named(t.getName());
 		}
 	}
 

--- a/src/test/resources/dml.adoc
+++ b/src/test/resources/dml.adoc
@@ -39,3 +39,37 @@ MATCH (person:person)
 WHERE person.id = 1
 DELETE person
 ----
+
+== Plain `DELETE` with alias
+
+The input
+
+[source,sql,id=t0_2,name=delete]
+----
+DELETE FROM person p
+----
+
+will be transpiled to
+
+[source,cypher,id=t0_2_expected]
+----
+MATCH (p:person)
+DELETE p
+----
+
+== Plain `DELETE` with alias and table mapping
+
+The input
+
+[source,sql,id=t0_3,name=delete,table_mappings=person:Person]
+----
+DELETE FROM person p
+----
+
+will be transpiled to
+
+[source,cypher,id=t0_3_expected]
+----
+MATCH (p:Person)
+DELETE p
+----

--- a/src/test/resources/predicates.adoc
+++ b/src/test/resources/predicates.adoc
@@ -62,7 +62,7 @@ will be transpiled to
 
 [source,cypher,id=t1_2_expected]
 ----
-MATCH (:p)
+MATCH (p:p)
 WHERE 1 = 3 AND 2 = 4
 OR (1 < 3 OR 1 = 3 AND 2 < 4)
 OR (1 < 3 OR 1 = 3 AND 2 <= 4)
@@ -161,7 +161,7 @@ will be transpiled to
 
 [source,cypher,id=t4_0_expected]
 ----
-MATCH (:p)
+MATCH (p:p)
 WHERE
   (1 IS NULL AND 2 IS NULL)
   OR (3 IS NOT NULL AND 4 IS NOT NULL)

--- a/src/test/resources/predicates.adoc
+++ b/src/test/resources/predicates.adoc
@@ -17,7 +17,7 @@ will be transpiled to
 
 [source,cypher,id=t1_0_expected]
 ----
-MATCH (:p)
+MATCH (p:p)
 WHERE ((1 = 1
     AND 2 = 2)
   OR 3 = 3)
@@ -35,7 +35,7 @@ will be transpiled to
 
 [source,cypher,id=t1_1_expected]
 ----
-MATCH (:p)
+MATCH (p:p)
 WHERE (NOT (1 = 1)
   XOR 2 = 2)
 RETURN 1
@@ -86,7 +86,7 @@ will be transpiled to
 
 [source,cypher,id=t2_0_expected]
 ----
-MATCH (:p)
+MATCH (p:p)
 WHERE (1 = 1
   AND 2 > 1
   AND 1 < 2
@@ -110,7 +110,7 @@ There is a shorter form in Cypher (`1 <= 2 <= 3`) but that's parsed into `AND` f
 
 [source,cypher,id=t2_1_expected]
 ----
-MATCH (:p)
+MATCH (p:p)
 WHERE (1 <= 2) AND (2 <= 3)
 RETURN 1
 ----
@@ -122,7 +122,7 @@ SELECT 1 FROM p WHERE 2 BETWEEN SYMMETRIC 3 AND 1
 
 [source,cypher,id=t2_2_expected]
 ----
-MATCH (:p)
+MATCH (p:p)
 WHERE (3 <= 2) AND (2 <= 1) OR (1 <= 2) AND (2 <= 3)
 RETURN 1
 ----
@@ -141,7 +141,7 @@ will be transpiled to
 
 [source,cypher,id=t3_0_expected]
 ----
-MATCH (:p)
+MATCH (p:p)
 WHERE (1 IS NULL
   AND 2 IS NOT NULL)
 RETURN 1


### PR DESCRIPTION
For aliased tables the last alias is already used all the time. If a table is not aliased, the name of the table can be used as node identifier, thus removing the need for doing this as an afterthought when aliasing is needed (in some DML for example).
